### PR TITLE
Improve retreat and performance and reliability

### DIFF
--- a/config/config.lua
+++ b/config/config.lua
@@ -2,28 +2,39 @@
 TICK_UPDATE_SQUAD_AI = 60 -- 60 ticks per second, how many ticks between updating squad AI (finding new targets, moving back into position, etc)
 DEFAULT_SQUAD_RADIUS = 2 -- how wide their attack_area radius is. not really used honestly..
 SOLDIER_MAX_AMMO = 100 -- unused, might be used later to simulate having to come back and resupply.
-SQUAD_SIZE_MIN_BEFORE_HUNT = 10 -- how many droids are required in a squad before they are commanded to attack nearest target. 
+SQUAD_SIZE_MIN_BEFORE_HUNT = 10 -- how many droids are required in a squad before they are commanded to attack nearest target.
 								-- override-able from settings combinator
-SQUAD_SIZE_MIN_BEFORE_RETREAT = 2 -- if a squad has been hunting and is down to this amount of guys left, head to nearest droid assembler for backup. 
+SQUAD_SIZE_MIN_BEFORE_RETREAT = 2 -- if a squad has been hunting and is down to this amount of guys left, head to nearest droid assembler for backup.
 								  -- override-able from settings combinator
 SQUAD_CHECK_RANGE = 20 -- range in tiles when a droid is spawned to check for existing squad to join, else creates its own squad
 SQUAD_HUNT_RADIUS = 5000 -- range in tiles, as a radius from squad. override-able from settings combinator
+AT_ASSEMBLER_RANGE = 20 -- range in tiles where we consider a droid or squad to be 'at' an assembler.
+MERGE_RANGE = 20
 
-ASSEMBLER_UPDATE_TICKRATE = 120 -- how often does the droid assembler building check for spawnable droid items in the output inv. 
+ASSEMBLER_UPDATE_TICKRATE = 120 -- how often does the droid assembler building check for spawnable droid items in the output inv.
 								-- how fast to spawn a droid once it's been actually assembled.
-								
+
 BOT_COUNTERS_UPDATE_TICKRATE = 60 -- how often does the robot army combinator count droids and update combinator signals?
 LONE_WOLF_CLEANUP_SCRIPT_PERIOD = 18000 -- how often to find and deal with droids that are "wanderers" and not in a squad. NOT USED YET
 GUARD_STATION_GARRISON_SIZE = 10 -- limit to how many a guard station will spawn based on counting nearby droids
 
+USE_TELEPORTATION_FIX = 1
+SANITY_CHECK_PERIOD_SECONDS = 30
+SANITY_CHECK_PROGRESS_DISTANCE = 30  -- 30 tiles in 60 seconds is veeerrry generous :)
+MERGE_CHECK_PERIOD_SECONDS = 5
 PRINT_SQUAD_DEATH_MESSAGES = 1
+PRINT_SQUAD_MERGE_MESSAGES = 1
+NEARBY_ASSEMBLERS_RANGE = 20
+ASSEMBLER_MERGE_TICKRATE = 180
 
 --CONFIG SETTINGS FOR THOSE WHO WANT TO SCALE THE DAMAGE AND HEALTH OF DROIDS
 HEALTH_SCALAR = 1.0 -- scales health by this value, default 1.0. 0.5 gives 50% health, 2.0 doubles their health etc.
 
-DAMAGE_SCALAR = 1.0 -- scales base damage by this value. default is 1.0. 0.5 makes 50% less base damage. 
-					-- 1.5 gives 50% more base damage. remember, technologies apply multipliers to the base damage so this value should take 
+DAMAGE_SCALAR = 1.0 -- scales base damage by this value. default is 1.0. 0.5 makes 50% less base damage.
+					-- 1.5 gives 50% more base damage. remember, technologies apply multipliers to the base damage so this value should take
 					-- that into consideration.
-					
+
 ARTIFACT_GRAB_RADIUS = 30
 GUARD_POLE_CONNECTION_RANGE = 30 -- this is for electrical connection range and therefore spacing of patrol poles, checking range is.
+
+PLAYER_VIEW_RADIUS = 60  -- this is very simplistic, but it's a start.

--- a/control.lua
+++ b/control.lua
@@ -4,13 +4,18 @@ require("robolib.util") -- some utility functions not necessarily related to rob
 require("robolib.robotarmyhelpers") -- random helper functions related to the robot army mod
 require("robolib.Squad") -- allows us to control squads, add entities to squads, etc.
 require("robolib.eventhandlers")
+require("robolib.onload")
 require("prototypes.DroidUnitList") -- so we know what is spawnable
 require("stdlib/log/logger")
 require("stdlib/game")
+
 LOGGER = Logger.new("robotarmy", "robot_army_logs", true, {log_ticks = true})
+
 global.runOnce = false
+
 function init_robotarmy()
     LOGGER.log("Robot Army mod Init script running...")
+
     if not global.Squads then
         global.Squads = {}
     end
@@ -50,6 +55,7 @@ function init_robotarmy()
     handleForceCreated(game.forces["neutral"])
     LOGGER.log("Robot Army mod Init script finished...")
 end
+
 
 script.on_init(init_robotarmy)
 

--- a/migrations/robotarmy_0.2.4.lua
+++ b/migrations/robotarmy_0.2.4.lua
@@ -83,6 +83,11 @@ for i, force in pairs(game.forces) do
                 local tick = getLeastFullTickTable(force) --get the least utilised tick in the tick table
                 table.insert(global.updateTable[force.name][tick], squad.squadID) --insert this squad reference to the least used tick for running its AI
             end
+			squad.memberUnitGroupErrors = {}
+			for key, soldier in pairs(squad.members) do
+				squad.memberUnitGroupErrors[key] = 0
+			end
+			squad.unitGroupFailures = 0
         end
     end
 end

--- a/robolib/Squad.lua
+++ b/robolib/Squad.lua
@@ -20,8 +20,7 @@ global.SquadTemplate = {squadID= 0, player=true, unitGroup = true, members = {si
 global.patrolState = {lastPole = nil,currentPole = nil,nextPole = nil,movingToNext = false}
 
 
-function createNewSquad(tableIN, player, entity)
-
+function createNewSquad(forceSquadsTable, entity)
     if not global.uniqueSquadId then
         global.uniqueSquadId = {}
     end
@@ -36,7 +35,6 @@ function createNewSquad(tableIN, player, entity)
 
     local newsquad = shallowcopy(global.SquadTemplate)
 
-    newsquad.player = player
     newsquad.force = entity.force
     newsquad.home = entity.position
     newsquad.surface = entity.surface
@@ -44,17 +42,68 @@ function createNewSquad(tableIN, player, entity)
     newsquad.squadID = squadID
     newsquad.patrolPoint1 = newsquad.home
     newsquad.patrolPoint2 = newsquad.home
-    newsquad.members = {}
     newsquad.command = commands.assemble
+
+    newsquad.members = {}
+	newsquad.memberUnitGroupErrors = {}
 	newsquad.numMembers = 0
 
-    tableIN[squadID] = newsquad
+	newsquad.lastBattleOrderFailures = 0
+	newsquad.lastBattleOrderTick = nil -- we use this to periodically sanity check the squad
+	newsquad.lastBattleOrderPos = nil
+
+    forceSquadsTable[squadID] = newsquad
 
     local tick = getLeastFullTickTable(entity.force) --get the least utilised tick in the tick table
     table.insert(global.updateTable[entity.force.name][tick], squadID) --insert this squad reference to the least used tick for running its AI
-	Game.print_force(entity.force, string.format("Created new squad %d", squadID))
+	-- Game.print_force(entity.force, string.format("Created new squad %d", squadID))
     --LOGGER.log(string.format( "Added squadref %d for AI update to tick table index %d", squadID, tick) )
     return newsquad
+end
+
+
+function deleteSquad(squad, suppress_msg)
+	local print_msg = not suppress_msg and PRINT_SQUAD_DEATH_MESSAGES
+
+	squad.members = nil -- get rid of members table first
+	squad.numMembers = 0
+
+	if squad.unitGroup and squad.unitGroup.valid then
+		squad.unitGroup.destroy()
+	end
+	if squad.unitGroup then squad.unitGroup = nil end
+
+	if global.Squads[squad.force.name][squad.squadID] then
+		if print_msg == 1 then
+			-- using stdlib, print message to entire force
+			Game.print_force(squad.force, string.format("Squad %d is no more...", squad.squadID))
+		end
+		LOGGER.log(string.format("Squad id %d from force %s has died/lost all its members...", squad.squadID, squad.force.name))
+
+		global.Squads[squad.force.name][squad.squadID] = nil  --set the entire squad itself to nil
+	end
+	global.RetreatingSquads[squad.force.name][squad.squadID] = nil
+	squad.deleted = true
+end
+
+
+function isOldBattleOrder(squad)
+	return not squad.lastBattleOrderTick or not squad.lastBattleOrderPos or
+		(squad.lastBattleOrderTick + SANITY_CHECK_PERIOD_SECONDS * 60 < game.tick and
+			 util.distance(squad.lastBattleOrderPos, squad.unitGroup.position)
+			 < SANITY_CHECK_PROGRESS_DISTANCE)
+		or (squad.retreatToAssembler and isTimeForMergeCheck(squad))
+end
+
+
+function isTimeForMergeCheck(squad)
+	return not squad.lastBattleOrderTick or
+		squad.lastBattleOrderTick + MERGE_CHECK_PERIOD_SECONDS * 60 < game.tick
+end
+
+
+function markSquadReadyForOrder(squad)
+	squad.lastBattleOrderTick = 0
 end
 
 
@@ -63,18 +112,30 @@ end
 -- or when a fresh squad is spawned
 function addMemberToSquad(squad, soldier)
  	if squad and soldier then
-		-- Game.print_force(squad.force, string.format(
-		-- 					 "Adding soldier %s to squad %d",
-		-- 					 tostring(soldier), squad.squadID))
-		Game.print_force(squad.force, string.format(
-							 "Adding soldier to squad %s",
-							 tostring(soldier)))
+		local msg = string.format("Adding member %s to squad %d of size %d", tostring(soldier), squad.squadID, squad.numMembers)
+		LOGGER.log(msg)
+
 		table.insert(squad.members, soldier)
+		table.insert(squad.memberUnitGroupErrors, 0)
 		squad.unitGroup.add_member(soldier)
 		squad.numMembers = squad.numMembers + 1
 	else
 		Game.print_force(Game.forces[1], "Tried to addMember to invalid table!")
 	end
+	return squad
+end
+
+
+function removeMemberFromSquad(squad, soldier_key)
+	if squad and soldier_key then
+		local msg = string.format("Removing member %d from squad %d of size %d!", soldier_key, squad.squadID, squad.numMembers)
+		LOGGER.log(msg)
+
+		squad.members[soldier_key] = nil
+		squad.memberUnitGroupErrors[soldier_key] = nil
+		squad.numMembers = squad.numMembers - 1
+	end
+	return squad
 end
 
 
@@ -84,16 +145,24 @@ function mergeSquads(squadA, squadB)
 		squadA.unitGroup.surface ~= squadB.unitGroup.surface
 	then return nil end -- then it can't be merged!
 
-	Game.print_force(squadB.force, string.format(
-						 "size of squad %d is %d",
-						 squadB.squadID, squadB.numMembers))
+	-- this helps us keep things sane as far as keeping the unitGroup in a reasonable position
+	if squadA.numMembers < squadB.numMembers then
+		local tempS = squadB
+		squadB = squadA
+		squadA = tempS
+	end
 
+	LOGGER.log(string.format("MERGING squad %d sz %d (%d,%d) into squad %d sz %d (%d,%d)!",
+							 squadB.squadID, squadB.numMembers,
+							 squadB.unitGroup.position.x, squadB.unitGroup.position.y,
+							 squadA.squadID, squadA.numMembers,
+							 squadA.unitGroup.position.x, squadA.unitGroup.position.y))
 	-- squadB.unitGroup.destroy()  -- do this first to see if it helps us move members over
 	-- squadB.unitGroup = nil
 	for key, soldier in pairs(squadB.members) do
 		if soldier and soldier.valid then
-			Game.print_force(squadA.force, string.format("mergeSquads adding droid %s to squad %d",
-										   tostring(soldier), squadA.squadID))
+			-- Game.print_force(squadA.force, string.format("mergeSquads adding droid %s to squad %d",
+			-- 							   tostring(soldier), squadA.squadID))
 			addMemberToSquad(squadA, soldier)
 		-- elseif soldier and not soldier.valid then
 		-- 	Game.print_force(squadA.force, "invalid soldier can't be merged")
@@ -102,40 +171,54 @@ function mergeSquads(squadA, squadB)
 		end
 	end
 
-	deleteSquad(squadB)
-	return validateSquadIntegrity(trimSquad(squadA))
+	deleteSquad(squadB, true)
+	local mergedSquad = validateSquadIntegrity(squadA)
+	if mergedSquad then
+		local msg = string.format("Merged squad %d into squad %d, now of size %d",
+								  squadB.squadID, squadA.squadID, mergedSquad.numMembers)
+		LOGGER.log(msg)
+		if PRINT_SQUAD_MERGE_MESSAGES then Game.print_force(mergedSquad.force, msg) end
+	end
+	return mergedSquad
 end
 
 
---input is table of squads (global.Squads[force.name]), and player to find closest to
-function getClosestSquad(tableIN, player, maxRange)
+function shouldHunt(squad)
+	return squad.numMembers >= getSquadHuntSize(squad.force)
+		or
+		(squad.command == commands.hunt and
+			 squad.numMembers > getSquadRetreatSize(squad.force))
+end
 
-    local leastDist = maxRange
-    local leastDistSquadID = nil
 
-    for key, squad in pairs(tableIN) do
-        --player.print("checking soldiers are in unitgroup...")
-        if validateSquadIntegrity(squad) then
-			local distance = util.distance(player.position, squad.unitGroup.position)
-			if distance <= leastDist then
-				leastDistSquadID = squad.squadID
-				leastDist = distance
-			end
+function isAttacking(squad)
+	return squad.unitGroup.state == defines.group_state.attacking_target or
+		squad.unitGroup.state == defines.group_state.attacking_distraction
+end
+
+
+function getSquadAvgPosition(squad)
+	local pos = nil
+	local totx = 0
+	local toty = 0
+	local count = 0
+	for key, unit in pairs(squad.members) do
+		if unit and unit.valid then
+			totx = totx + unit.position.x
+			toty = toty + unit.position.y
+			count = count + 1
 		end
-    end
-
-    if (leastDist == maxRange or leastDistSquadID == nil) then
-        --player.print("getClosestSquad - no squad found or squad too far away")
-        return nil
-    end
-
-    --player.print(string.format("closest squad found: %d tiles away from player", leastDist))
-    return leastDistSquadID
+	end
+	if count then
+		pos = { x = totx / count, y = toty / count }
+	end
+	return pos
 end
 
 
 --input is table of squads (global.Squads[force.name]), and position to find closest to
-function getClosestSquadToPos(forceSquads, position, maxRange, ignore_squad, only_with_squad_command)
+function getClosestSquadToPos(forceSquads, position, maxRange, ignore_squad,
+							  only_with_squad_commands)
     local leastDist = maxRange
 	local closest_squad = nil
 
@@ -144,10 +227,9 @@ function getClosestSquadToPos(forceSquads, position, maxRange, ignore_squad, onl
 			goto continue
 		end
 		squad = validateSquadIntegrity(squad)
-		Game.print_force("Failed to validate squad in getClosestSquadToPos")
         if squad then
-			if only_with_squad_command and only_with_squad_command ~= squad.command then
-				goto continue
+			if only_with_squad_commands and not table.contains(only_with_squad_commands, squad.command) then
+				goto continue -- we're not interested in a squad with this active command
 			end
             local distance = util.distance(position, squad.unitGroup.position)
             if distance <= leastDist then
@@ -168,62 +250,113 @@ function getClosestSquadToPos(forceSquads, position, maxRange, ignore_squad, onl
 end
 
 
--- checks that all entities in the "members" sub table are present in the unitgroup
-function validateSquadIntegrity(squad)
-    if not squad then  return nil end --LOGGER.log("tried to validate a squad that doesn't exist!")
-    if not squad.members then  return nil end --LOGGER.log("Tried to validate a squad with no member table!")
-
-	squad.members.size = nil -- removing old 'size' table entry
-
-    --make sure the unitgroup is even available, if it's not there for some reason, create it.
-    if not squad.unitGroup or not squad.unitGroup.valid then
-        --LOGGER.log("unitgroup was invalid, making a new one")
-        local pos = nil
-        for key, unit in pairs(squad.members) do
-            if unit and unit.valid then
-                pos = unit.position
-            end
-        end
-
-        if pos ~= nil then
-            local surface = getSquadSurface(squad)
-            squad.unitGroup = surface.create_unit_group({position=pos, force=squad.force})
-        else
-			Game.print_force(squad.force, "Bad error -- cannot find position for any unit in squad.")
-            return nil --gtfo, there is something wrong here
-        end
-    end
-
-    ::retryCheckMembership::
-    for key, soldier in pairs(squad.members) do
-		if not soldier or not soldier.valid then
-			squad.members[key] = nil -- this also happens in trimSquad
-			squad.numMembers = squad.numMembers - 1
-		elseif not table.contains(squad.unitGroup.members, soldier) then
-			if soldier.surface == squad.unitGroup.surface then
-				Game.print_force(squad.force, string.format(
-									 "syncing soldier %s in UG %s to squad ID %d's unitgroup %s at position (%d,%d), distance %d",
-									 tostring(soldier), tostring(soldier.unit_group),
-									 squad.squadID, tostring(squad.unitGroup),
-									 soldier.position.x, soldier.position.y,
-									 util.distance(soldier.position, squad.unitGroup.position)))
-				squad.unitGroup.add_member(soldier)
-			else
-				Game.print_force(squad.force, string.format(
-									 "destroying unit group for squad ID %d", squad.squadID))
-				--LOGGER.log("Destroying unit group, and creating a replacement on the correct surface")
-				squad.unitGroup.destroy()
-				soldier.surface.create_unit_group({position=soldier.position, force=soldier.force})
-				--goto retryCheckMembership
+-- on avg twice as fast if you don't actually care about it being *the nearest* squad
+function getCloseEnoughSquadToSquad(forceSquads, squad, closeEnough, only_with_commands)
+	for key, otherSquad in pairs(forceSquads) do
+		if squad == otherSquad then goto continue end
+		if only_with_commands and not table.contains(only_with_commands, otherSquad.command) then
+			goto continue
+		end
+		otherSquad = validateSquadIntegrity(otherSquad)
+		if otherSquad then
+			local distance = util.distance(squad.unitGroup.position,
+										   otherSquad.unitGroup.position)
+			if distance <= closeEnough then
+				LOGGER.log(string.format("Choosing close-enough squad %d at distance %d from squad %d",
+										 otherSquad.squadID, distance, squad.squadID))
+				return otherSquad
 			end
 		end
-    end
-
-	return squad
+		::continue::
+	end
+	return nil
 end
 
 
-function trimSquad(squad, print_msg)
+function teleportSoldierToUnitGroup(soldier, unitGroup)
+	-- naive teleport to unitgroup location
+	local teleport_pos = soldier.surface.find_non_colliding_position(
+		soldier.name, unitGroup.position, 5, 1)
+	if teleport_pos then
+		if not soldier.teleport(teleport_pos) then
+			local msg = "Failed to teleport soldier to squad!!!"
+			LOGGER.log(msg)
+		else
+			unitGroup.add_member(soldier)
+		end
+	else
+		local msg = "Failed to find teleport position!!"
+		LOGGER.log(msg)
+	end
+end
+
+function retreatMisbehavingLoneWolf(soldier)
+	-- we've failed to 'fix' the soldier - remove it from the group
+	-- attempt to retreat to a nearby assembler
+	local assembler, distance = findClosestAssemblerToPosition(
+		global.DroidAssemblers[soldier.force.name], soldier.position)
+	if assembler then
+		local loneWolfSquad = createNewSquad(global.Squads[soldier.force.name], soldier)
+		if loneWolfSquad then
+			addMemberToSquad(loneWolfSquad, soldier)
+			orderSquadToRetreat(loneWolfSquad)
+		end
+	end
+end
+
+
+function disbandAndRetreatEntireSquad(squad)
+	for key, soldier in pairs(squad.members) do
+		removeMemberFromSquad(squad, key)
+		retreatMisbehavingLoneWolf(soldier)
+	end
+end
+
+
+function recreateUnitGroupForSquad(squad)
+	squad.lastBattleOrderTick = 0 -- needs a new command
+
+	local pos = getSquadAvgPosition(squad)
+
+	local unitGroup = nil
+	if pos ~= nil then
+		if squad.lastBattleOrderFailures < 10 then
+			local msg = string.format("unitgroup for squad %d size %d was invalid, making a new one at (%d,%d)",
+									  squad.squadID, squad.numMembers, pos.x, pos.y)
+			LOGGER.log(msg)
+			local surface = getSquadSurface(squad)
+			unitGroup = surface.create_unit_group({position=pos, force=squad.force})
+			if not squad.unitGroup then
+				local msg = string.format("Very bad -- cannot create unit group for squad %d", squad.squadID)
+				LOGGER.log(msg)
+			end
+		end
+	else
+		local msg = string.format("Bad error -- cannot find position for any unit in squad %d.", squad.squadID)
+		LOGGER.log(msg)
+	end
+	return unitGroup
+end
+
+
+-- this function is sufficient for basic operations, but does not validate that the squad has members.
+function squadStillExists(squad)
+	if squad and squad.members and global.Squads[squad.force.name][squad.squadID] then
+		if not squad.numMembers then
+			squad = trimSquad(squad)
+		end
+		if not squad.unitGroup or not squad.unitGroup.valid then -- it very likely doesn't have members
+			squad = validateSquadIntegrity(squad)
+		end
+		return squad
+	else
+		return trimSquad(squad)
+	end
+end
+
+
+function trimSquad(squad, suppress_msg)
+	if squad.deleted then return nil end
     if squad then
         --player.print(string.format("trimming squad %s, id %d, member size %d", squad, squad.squadID, squad.numMembers))
 		squad.numMembers = 0
@@ -233,14 +366,16 @@ function trimSquad(squad, print_msg)
 				if droid and droid.valid then
 					squad.numMembers = squad.numMembers + 1
 				else
-					Game.print_force(squad.force, "trimSquad: removing invalid droid from squad.")
+					-- Game.print_force(squad.force, "trimSquad: removing invalid droid from squad.")
 					squad.members[key] = nil
+					if squad.memberUnitGroupErrors then
+						squad.memberUnitGroupErrors[key] = nil
+					end
 				end
 			end
 		end
 		if squad.numMembers == 0 then
-			--Game.print_force(squad.force, string.format("trimSquad Deleting squad %d", squad.squadID))
-			deleteSquad(squad, print_msg)
+			deleteSquad(squad, suppress_msg)
 			return nil
 		end
     end
@@ -248,34 +383,143 @@ function trimSquad(squad, print_msg)
 end
 
 
-function deleteSquad(squad, print_msg)
-	print_msg = print_msg or PRINT_SQUAD_DEATH_MESSAGES  -- default value for argument
-
-	squad.members = nil -- get rid of members table first
-
+function isSquadInRetreatNearAssembler(squad)
+	local squad_position = nil
 	if squad.unitGroup and squad.unitGroup.valid then
-		squad.unitGroup.destroy()
+		squad_position = squad.unitGroup.position
+	else
+		squad_position = getSquadAvgPosition(squad)
 	end
-	if squad.unitGroup then squad.unitGroup = nil end
+	if not squad_position then return true end -- this is an unfortunate but necessary default
 
-	if print_msg == 1 then
-		-- using stdlib, print message to entire force
-		Game.print_force(squad.force, string.format("Squad %d is no more...", squad.squadID))
+	if squad.retreatToAssembler and squad.retreatToAssembler.valid and
+		util.distance(squad_position, squad.retreatToAssembler.position) < AT_ASSEMBLER_RANGE
+	then
+		return true
+	else
+		local nearestAssembler = findClosestAssemblerToPosition(
+			global.DroidAssemblers[force.name], squad_position)
+		if nearestAssembler and util.dist(nearestAssembler.position, squad_position) then
+			return true
+		end
 	end
-	--LOGGER.log(string.format("Squad id %d from force %s has died/lost all its members...", squad.squadID, squad.force.name))
-
-	global.Squads[squad.force.name][squad.squadID] = nil  --set the entire squad itself to nil
+	return false
 end
 
 
-function trimSquads(forces)
-    for _, force in pairs(forces) do
-        if global.Squads and global.Squads[force.name] then
-            for key, squad in pairs(global.Squads[force.name]) do
-				trimSquad(squad)
-            end
-        end
+-- checks that all entities in the "members" sub table are present in the unitgroup
+function validateSquadIntegrity(squad)
+	if squad then squad = trimSquad(squad) end
+    if not squad then return nil end --LOGGER.log("tried to validate a squad that doesn't exist!")
+
+	squad = inGameSquadMigration(squad)
+
+    --make sure the unitgroup is even available, if it's not there for some reason, create it.
+    if not squad.unitGroup or not squad.unitGroup.valid then
+		squad.lastBattleOrderFailures = squad.lastBattleOrderFailures + 3
+		LOGGER.log(string.format("--- WARNING: squad %d at +++ order failures %d", squad.squadID,
+								 squad.lastBattleOrderFailures))
+		squad.unitGroup = recreateUnitGroupForSquad(squad)
+		if not squad.unitGroup or not squad.unitGroup.valid then
+			if squad.lastBattleOrderFailures >= 10 and not isSquadInRetreatNearAssembler(squad) then
+				-- we've lost our unit group too many times. Notify the player and retreat the squad.
+				local msg = string.format("ERROR: Squad %d of size %d at position (%d,%d) has failed its last %d commands. It has been disbanded and its units will retreat.",
+										  squad.squadID, squad.numMembers,
+										  pos.x, pos.y, squad.lastBattleOrderFailures)
+				LOGGER.log(msg)
+				Game.print_force(squad.force, msg)
+				disbandAndRetreatEntireSquad(squad)
+				deleteSquad(squad, true)
+			else
+				LOGGER.log(string.format("ERROR: Cannot create unitGroup for squad %d of size %d; it is being destroyed.",
+										 squad.squadID, squad.numMembers))
+				Game.print_force(squad.force, string.format(
+									 "ERROR: Squad %d has lost cohesion and is being disbanded.",
+									 squad.squadID))
+				deleteSquad(squad)
+			end
+			return nil
+		end
+    elseif squad.lastBattleOrderFailures > 0 and squad.lastBattleOrderTick + 60 < game.tick then
+		squad.lastBattleOrderFailures = squad.lastBattleOrderFailures - 1
+		LOGGER.log(string.format("squad %d at - order failures %d", squad.squadID, squad.lastBattleOrderFailures))
+	end
+
+	-- check each droid individually to confirm that it is part of the unitGroup
+    ::retryCheckMembership::
+    for key, soldier in pairs(squad.members) do
+		if not soldier or not soldier.valid then
+			removeMemberFromSquad(squad, key)
+		elseif not table.contains(squad.unitGroup.members, soldier) then
+			if soldier.surface == squad.unitGroup.surface then
+				squad.memberUnitGroupErrors[key] = squad.memberUnitGroupErrors[key] + 1
+				if squad.memberUnitGroupErrors[key] < 3 then
+					local msg = string.format("Re-adding soldier %d of squad %d to unitGroup, attempt %d",
+											  key, squad.squadID, squad.memberUnitGroupErrors[key])
+					LOGGER.log(msg)
+					squad.unitGroup.add_member(soldier)
+				elseif squad.memberUnitGroupErrors[key] < 5 and USE_TELEPORTATION_FIX and
+					not global_canAnyPlayersSeeThisEntity(soldier) and
+					not global_canAnyPlayersSeeThisEntity(squad.unitGroup)
+				then -- we can cheat by teleporting the entity :/
+					local msg = string.format(
+						"   >>>>>  Teleporting wayward soldier %d about %d to its squad's (%d) location (%d,%d)",
+						key, util.distance(soldier.position,
+										   squad.unitGroup.position),
+						squad.squadID, squad.unitGroup.position.x,
+						squad.unitGroup.position.y)
+					LOGGER.log(msg)
+					teleportSoldierToUnitGroup(soldier, squad.unitGroup)
+				else -- tried teleporting a few times, or didn't because player present
+					if not isSquadInRetreatNearAssembler(squad) then
+						local msg = string.format(
+							"!*!*!*!*! ERROR: After many attempts, failed to reintegrate soldier %d at (%d,%d) with squad %d.",
+							key, soldier.position.x, soldier.position.y, squad.squadID)
+						LOGGER.log(msg)
+						removeMemberFromSquad(squad, soldier_key)
+						retreatMisbehavingLoneWolf(soldier)
+					else
+						LOGGER.log("WARNING: Can't remove misbehaving soldier from squad and ask it to retreat " ..
+									   "because it's already at the nearest assembler.")
+					end
+				end
+			else
+				local msg = string.format("Destroying unit group for squad ID %d!!", squad.squadID)
+				LOGGER.log(msg)
+				squad.unitGroup.destroy()
+				soldier.surface.create_unit_group({position=soldier.position, force=soldier.force})
+				squad.lastBattleOrderTick = 0 -- needs a new command
+				--goto retryCheckMembership
+			end
+		elseif squad.memberUnitGroupErrors[key] > 0 then
+			squad.memberUnitGroupErrors[key] = squad.memberUnitGroupErrors[key] - 1
+		end
     end
+
+	return squad
+end
+
+
+function orderToAssembler(orderable, assembler)
+	local position = getDroidSpawnLocation(assembler)
+	if position ~= -1 then
+		-- RETREAT!
+		-- orderable.set_command({type=defines.command.go_to_location,
+		-- 					   destination=position,
+		-- 					   distraction=defines.distraction.by_enemy})
+		orderable.set_command({type=defines.command.compound,
+							   structure_type=defines.compound_command.return_last,
+							   commands={
+								   {type=defines.command.go_to_location,
+									destination=position,
+									distraction=defines.distraction_by_enemy},
+								   {type=defines.command.wander,
+									destination=position,
+									distraction=defines.distraction_by_enemy},
+		}})
+	else
+		LOGGER.log("Failed to find a droid spawn position near the requested assembler!")
+	end
 end
 
 
@@ -283,14 +527,13 @@ function revealChunksBySquad(squad)
     if squad and squad.unitGroup and squad.unitGroup.valid then
         if squad.numMembers > 0 then  --if there are troops in a valid group in a valid squad.
             local position = squad.unitGroup.position
-
             --this area should give approx 3x3 chunks revealed
             local area = {left_top = {position.x-32, position.y-32}, right_bottom = {position.x+32, position.y+32}}
-
             local surface = getSquadSurface(squad)
 
             if not surface then
-                --LOGGER.log(string.format("ERROR: Surface for squad ID %d is missing or can't be determined! revealSquadChunks", squad.squadID))
+                LOGGER.log(string.format("ERROR: Surface for squad ID %d is missing or can't be determined! revealSquadChunks",
+										 squad.squadID))
                 return
             end
             squad.force.chart(surface, area) --reveal the chunk they are in.
@@ -348,50 +591,81 @@ function grabArtifactsBySquad(squad)
 end
 
 
-function handleDroidSpawned(event)
-    local droid = event.created_entity
-    local player = game.players[event.player_index]
-    local force = droid.force
-    --player.print(string.format("Processing new entity %s spawned by player %s", droid.name, player.name) )
-    local position = droid.position
+function orderSquadToWander(squad, position)
+	squad.lastBattleOrderTick = game.tick
+	squad.lastBattleOrderPos = squad.unitGroup.position
+	debugSquadOrder(squad, "WANDER", position)
+	squad.unitGroup.set_command({type=defines.command.wander,
+								 destination = position,
+								 distraction=defines.distraction.by_enemy})
+	squad.unitGroup.start_moving()
+end
 
-    --if this is the first time we are using the player's tables, make it
-    if not global.Squads[force.name] then
-        global.Squads[force.name] = {}
-    end
 
-    local squad = getClosestSquadToPos(global.Squads[force.name], droid.position, SQUAD_CHECK_RANGE)
-    if squad and getSquadSurface(squad) ~= droid.surface then
-        squad = nil  --we cannot allow a squad to be joined if it's on the wrong surface
-    end
+function orderSquadToAttack(squad, position)
+	--make sure squad is good, then set command
+	squad.command = commands.hunt -- sets the squad's high level role to hunt.
+	if squad.lastBattleOrderTick + 60 >= game.tick then
+		-- we may be trying to issue bad attack orders...
+		squad.lastBattleOrderFailures = squad.lastBattleOrderFailures + 2
+		LOGGER.log(string.format("--- WARNING: Squad %d at ++ order failures %d", squad.squadID, squad.lastBattleOrderFailures))
+	end
+	squad.lastBattleOrderTick = game.tick
+	squad.lastBattleOrderPos = squad.unitGroup.position
 
-    if not squad then
-        --if we didnt find a squad nearby, create one
-        squad = createNewSquad(global.Squads[force.name], player, droid)
-		if not squad then
-			Game.print_force(force, "Failed to create squad for newly spawned droid!!")
+	squad.retreatAssembler = nil
+
+	debugSquadOrder(squad, "*ATTACK*", position)
+	squad.unitGroup.set_command({type=defines.command.attack_area,
+								 destination=position,
+								 radius=50, distraction=defines.distraction.by_anything})
+	squad.unitGroup.start_moving()
+end
+
+
+function debugPrintSquad(squad)
+	local ug_state = -1
+	if squad.unitGroup then ug_state = squad.unitGroup.state end
+	local msg = string.format("sqd %d, sz %d, ug? %s, ugst %s, cmd %s, tick %d",
+							  squad.squadID, squad.numMembers, tostring(squad.unitGroup ~= nil),
+							  tostring(ug_state), tostring(squad.command), game.tick)
+	Game.print_force(squad.force, msg)
+	LOGGER.log(msg)
+end
+
+
+function debugSquadOrder(squad, orderName, position)
+	local msg = string.format("Ordering squad %d (%d: %d,%d) to %s at (%d,%d).",
+							  squad.squadID, squad.numMembers,
+							  squad.unitGroup.position.x, squad.unitGroup.position.y,
+							  orderName, position.x, position.y)
+	LOGGER.log(msg)
+end
+
+
+function inGameSquadMigration(squad)
+	-- missed migration to 0.2.4
+	squad.members.size = nil -- removing old 'size' table entry
+	if not squad.memberUnitGroupErrors then
+		squad.memberUnitGroupErrors = {}
+		for key, soldier in pairs(squad.members) do
+			squad.memberUnitGroupErrors[key] = 0
 		end
-    end
+	end
+	if not squad.lastBattleOrderFailures then
+		squad.lastBattleOrderFailures = 0
+		LOGGER.log(string.format("squad %d at 0 failures %d", squad.squadID, squad.lastBattleOrderFailures))
+	end
+	if not squad.lastBattleOrderTick then squad.lastBattleOrderTick = 0 end
+	return squad
+end
 
-    addMemberToSquad(squad, droid)
 
-    --code to handle adding new member to a squad that is guarding/patrolling
-    if event.guard == true then
-        if squad.command ~= commands.guard then
-            squad.command = commands.guard
-            squad.home = event.guardPos
-            --game.players[1].print(string.format("Setting guard squad to wander around %s", event.guardPos))
-
-            --check if the squad it just joined is patrolling,
-			-- if it is, don't force any more move commands because it will be disruptive!
-            if not squad.patrolState or
-				(squad.patrolState and squad.patrolState.currentWaypoint == -1)
-			then
-                --Game.print_force(droid.force, "Setting move command to squad home..." )
-                squad.unitGroup.set_command({type=defines.command.wander,
-											 destination = squad.home,
-											 distraction=defines.distraction.by_enemy})
-                squad.unitGroup.start_moving()
+function trimSquads(forces)
+    for _, force in pairs(forces) do
+        if global.Squads and global.Squads[force.name] then
+            for key, squad in pairs(global.Squads[force.name]) do
+				trimSquad(squad)
             end
         end
     end

--- a/robolib/SquadControl.lua
+++ b/robolib/SquadControl.lua
@@ -1,86 +1,55 @@
 require("config.config")
 require("util")
+require("robolib.Squad")
 require("robolib.util")
+require("robolib.retreat")
 require("stdlib/log/logger")
 require("stdlib/game")
 
-
 function updateSquad(squad)
-    if validateSquadIntegrity(trimSquad(squad)) then -- if not, that means this squad has been deleted
-		if squad.unitGroup and squad.unitGroup.valid then  --important for basically every AI command/routine
-			--LOGGER.log(string.format( "AI for squadref %d in tick table index %d is being executed now...", squadref, tickProcessIndex) )
-			--CHECK IF SQUAD IS A GUARD SQUAD, AND CHOOSE WHICH AI FUNCTION TO CALL
-			if squad.command == commands.guard then
-				executeGuardAI(squad) --remove checks in this function for command and validity
-			elseif not squad.rally then
-				executeBattleAI(squad)
-			end
-
-			revealChunksBySquad(squad)
-			grabArtifactsBySquad(squad)
+    if squadStillExists(squad) then -- if not, that means this squad has been deleted
+		--LOGGER.log(string.format( "AI for squadref %d in tick table index %d is being executed now...", squadref, tickProcessIndex) )
+		--CHECK IF SQUAD IS A GUARD SQUAD, AND CHOOSE WHICH AI FUNCTION TO CALL
+		if squad.command == commands.guard then
+			executeGuardAI(squad)
+		elseif not squad.rally then
+			executeBattleAI(squad)
+		else
+			squad = validateSquadIntegrity(squad)
 		end
+
+		revealChunksBySquad(squad)
+		grabArtifactsBySquad(squad)
 	end
 end
 
 
-function orderSquadToAssembler(squad, assembler)
-	-- need to keep retreating towards assembler
-	--player.print(string.format("Closest assembler found was at location x %d : y %d", assembler.position.x, assembler.position.y ))
-	local location = getDroidSpawnLocation(assembler)
-	if location ~= -1 then
-		-- RETREAT!
-		-- player.print(string.format("Sending squad to assembler at location x %d : y %d", location.x, location.y ))
-		squad.unitGroup.set_command({type=defines.command.go_to_location,
-									 destination=location,
-									 radius=DEFAULT_SQUAD_RADIUS,
-									 distraction=defines.distraction.by_enemy})
-		squad.unitGroup.start_moving()
+function attemptToMergeSquadWithNearbyAssemblingSquad(squad, otherSquads, range)
+	if not squad.unitGroup then
+		LOGGER.log(string.format("Attempting to merge squad %d %s", squad.squadID, tostring(squad)))
 	else
-		-- player.print("Couldn't get location for droid spawn location!!")
+		local msg = string.format("Attempting to merge squad %d at (%d,%d) with a nearby assembling squad.",
+								  squad.squadID, squad.unitGroup.position.x, squad.unitGroup.position.y)
+		LOGGER.log(msg)
 	end
-end
-
-
-function attemptToMergeRetreatingSquadWithNearestAssemblingSquad(squad, range)
-	local closest_squad = getClosestSquadToPos(global.Squads[squad.force.name],
-											   squad.unitGroup.position,
-											   range,
-											   squad, -- ignore self
-											   commands.assemble)
-	Game.print_force(squad.force, "Attempting to merge squad")
+	local closest_squad = getCloseEnoughSquadToSquad(
+		otherSquads, squad, range, {commands.assemble})
 	if closest_squad then
-		local oldsquadID = closest_squad.squadID
-		if mergeSquads(squad, closest_squad) then
-			Game.print_force(squad.force, string.format(
-								 "Merged squad %d into squad %d",
-								 oldsquadID, squad.squadID))
-			if squad.numMembers >= getSquadHuntSize(squad.force) then
-				squad.command = commands.hunt
-			else
-				squad.command = squad.assemble
-			end
+		local mergedSquad = mergeSquads(squad, closest_squad)
+		if mergedSquad then
+			return true, mergedSquad
+		else
+			local msg = string.format("Failed to merge squad %d into squad %d!",
+									  squad.squadID, closestSquad.squadID)
+			-- Game.print_force(squad.force, msg)
+			LOGGER.log(msg)
 		end
+	else
+		local msg = string.format("Failed to find a close enough squad to %d for merging.", squad.squadID)
+		-- Game.print_force(squad.force, msg)
+		LOGGER.log(msg)
 	end
-end
-
-
-function orderSquadToRetreat(squad)
-    if squad.command == commands.hunt then
-        -- player.print(string.format("Sending under-strength squad id %d back to base for resupply...", squad.squadID ))
-		assembler, distance = global_findClosestForceAssemblerToPosition(
-			squad.unitGroup.position, squad.force.name)
-		if assembler then
-			ASSEMBLER_RANGE = 10  -- this should eventually be configurable
-			if distance > ASSEMBLER_RANGE then
-				orderSquadToAssembler(squad, assembler)
-			else
-				-- squad has arrived at assembler/retreat location
-				squad.command = commands.assemble
-				attemptToMergeRetreatingSquadWithNearestAssemblingSquad(
-					squad, ASSEMBLER_RANGE * 2)
-			end
-		end
-    end
+	return false, squad
 end
 
 
@@ -88,27 +57,22 @@ function orderSquadToHunt(squad)
     --get nearest enemy unit to the squad.
     --find the nearest enemy to the squad that is an enemy of the player's force, and max radius of 5000 tiles (10k tile diameter)
     local surface = getSquadSurface(squad)
-
     if not surface then
-        --LOGGER.log(string.format("ERROR: Surface for squad ID %d is missing or can't be determined! sendSquadsToBattle", squad.squadID))
+        LOGGER.log(string.format("ERROR: Surface for squad ID %d is missing or can't be determined!", squad.squadID))
         return
     end
 
     local huntRadius = getSquadHuntRange(squad.force)
-
-    local nearestEnemy = surface.find_nearest_enemy({position = squad.unitGroup.position, max_distance = huntRadius, force = squad.force })
+    local nearestEnemy = surface.find_nearest_enemy({position = squad.unitGroup.position,
+													 max_distance = huntRadius,
+													 force = squad.force })
     if nearestEnemy then
         -- check if they are in a charted area
-
         local charted = true   -- = player.force.is_chunk_charted(player.surface, nearestEnemy.position)
         if charted then
-            --player.print("Sending squad off to battle...")
-            --make sure squad is good, then set command
-            squad.command = commands.hunt -- sets the squad's high level role to hunt. not really used yet
-            squad.unitGroup.set_command({type=defines.command.attack_area, destination= nearestEnemy.position, radius=50, distraction=defines.distraction.by_anything})
-            squad.unitGroup.start_moving()
+			orderSquadToAttack(squad, nearestEnemy.position)
         else
-            Game.print_force(squad.force, "enemy found but in un-charted area...") -- this is debug spam - if we see this, deal with it properly in code and remove this
+            LOGGER.log("enemy found but in un-charted area...") -- this is debug spam - if we see this, deal with it properly in code and remove this
         end
     else
         --Game.print_force(squad.force, "cannot find nearby target!!") -- this is debug spam - if we see this, deal with it properly in code and remove this
@@ -121,135 +85,154 @@ end
 function executeBattleAI(squad)
 	if squad.unitGroup.state == defines.group_state.gathering
 		or squad.unitGroup.state == defines.group_state.finished
-	then
-		-- either hunt or retreat
-		if (squad.numMembers >= getSquadHuntSize(squad.force)
-			-- large enough to start hunting
-				or
-				-- already hunting and not small enough to retreat
-				(squad.command == commands.hunt and
-					 squad.numMembers > getSquadRetreatSize(squad.force)))
-		then
+		or (isOldBattleOrder(squad) and not isAttacking(squad))
+	then -- needs battle orders of some kind
+		if not validateSquadIntegrity(squad) then return end
+		if shouldHunt(squad) then
+			-- local msg = string.format("ordering squad %d to hunt", squad.squadID)
+			-- Game.print_force(squad.force, msg)
 			orderSquadToHunt(squad)
 		else
 			orderSquadToRetreat(squad)
+			-- if squad.retreatToAssembler and squad.retreatToAssembler.valid then
+			-- 	squad.lastBattleOrderTick = game.tick
+			-- 	orderToAssembler(squad.unitGroup, squad.retreatToAssembler)
+			-- else
+			-- 	assembler, distance = findClosestAssemblerToPosition(
+			-- 		global.DroidAssemblers[squad.force.name],
+			-- 		squad.unitGroup.position)
+			-- 	if distance > AT_ASSEMBLER_RANGE then
+			-- 		orderSquadToRetreat(squad)
+			-- 	elseif assembler and (squad.command == commands.hunt or isTimeForMergeCheck(squad)) then
+			-- 		squad.command = commands.assemble
+			-- 		success, squad = attemptToMergeSquadWithNearbyAssemblingSquad(
+			-- 			squad, global.RetreatingSquads[squad.force.name], AT_ASSEMBLER_RANGE * 2)
+			-- 		if shouldHunt(squad) then
+			-- 			orderSquadToHunt(squad)
+			-- 		else
+			-- 			orderSquadToWander(squad, getDroidSpawnLocation(assembler))
+			-- 		end
+			-- 	end
+			-- end
 		end
 	end -- other states include moving, attacking, or attacking distraction.
-	    -- in these cases, leave the droids alone until they 'need' to be ordered again.
+	-- in these cases, leave the droids alone until they 'need' to be ordered again.
 end
 
 
 function executeGuardAI(squad)
-    if squad.command == commands.guard then
-        local surface = getSquadSurface(squad)
+	local surface = getSquadSurface(squad)
 
-        if not surface then
-            --LOGGER.log(string.format("ERROR: Surface for squad ID %d is missing or can't be determined! guardAIUpdate", squad.squadID))
-            return
-        end
+	if not surface then
+		--LOGGER.log(string.format("ERROR: Surface for squad ID %d is missing or can't be determined! guardAIUpdate", squad.squadID))
+		return
+	end
 
-        local areaTopLeft = {x=squad.unitGroup.position.x-32, y=squad.unitGroup.position.y-32}
-        local areaBottomRight = {x=squad.unitGroup.position.x+32, y=squad.unitGroup.position.y+32}
-        local areaCheck = {areaTopLeft, areaBottomRight}
+	local areaTopLeft = {x=squad.unitGroup.position.x-32, y=squad.unitGroup.position.y-32}
+	local areaBottomRight = {x=squad.unitGroup.position.x+32, y=squad.unitGroup.position.y+32}
+	local areaCheck = {areaTopLeft, areaBottomRight}
 
-        local poleList = surface.find_entities_filtered{area = {areaTopLeft, areaBottomRight}, squad.unitGroup.position, name="patrol-pole"}
-        local poleCount = table.countValidElements(poleList)
-        if(poleCount > 1) then
-            if not squad.patrolState then
-                --Game.print_all("Making patrolstate table...")
-                squad.patrolState = {}
+	local poleList = surface.find_entities_filtered{area = {areaTopLeft, areaBottomRight}, squad.unitGroup.position, name="patrol-pole"}
+	local poleCount = table.countValidElements(poleList)
+	if poleCount > 1 then
+		if not squad.patrolState then
+			--Game.print_all("Making patrolstate table...")
+			squad.patrolState = {}
 
-                squad.patrolState.nextPole = nil
-                squad.patrolState.currentPole = nil
-                squad.patrolState.lastPole = nil
-                squad.patrolState.movingToNext = false
-                squad.patrolState.waypointList = {}
-                squad.patrolState.currentWaypoint = -1
-                squad.patrolState.arrived = false
-                squad.patrolState.waypointDirection = 1
-            end
+			squad.patrolState.nextPole = nil
+			squad.patrolState.currentPole = nil
+			squad.patrolState.lastPole = nil
+			squad.patrolState.movingToNext = false
+			squad.patrolState.waypointList = {}
+			squad.patrolState.currentWaypoint = -1
+			squad.patrolState.arrived = false
+			squad.patrolState.waypointDirection = 1
+		end
 
-            if not next(squad.patrolState.waypointList) then
-                --from the squad's current position, build a waypoint list using patrol poles found in sequence.
+		if not next(squad.patrolState.waypointList) then
+			--from the squad's current position, build a waypoint list using patrol poles found in sequence.
+			--Game.print_all(string.format("polecount %d", poleCount))
+			buildWaypointList(squad.patrolState.waypointList, surface, areaCheck, squad, force)
+		end
 
-                --Game.print_all(string.format("polecount %d", poleCount))
-                buildWaypointList(squad.patrolState.waypointList, surface, areaCheck, squad, force)
+		local waypointCount = table.countNonNil(squad.patrolState.waypointList)
+		--Game.print_all(string.format("Squad's waypoint count: %d", waypointCount))
+		if(waypointCount >= 2) then
+			if(squad.patrolState.currentWaypoint == -1) then
+				--Game.print_all("Setting up initial conditions...")
+				squad.patrolState.currentWaypoint = 0
+				squad.patrolState.movingToNext = false
+				squad.patrolState.arrived = true
+			end
+			--check if we are going to a waypoint, if we are, check if we are close yet
+			if(squad.patrolState.movingToNext == true) then
+				--get distance from squad position to the current waypoint
+				local dist = util.distance(squad.unitGroup.position, squad.patrolState.waypointList[squad.patrolState.currentWaypoint])
+				--Game.print_all("Checking if squad is near waypoint...")
+				if dist < 5 then
+					squad.patrolState.movingToNext = false
+					squad.patrolState.arrived = true
+					--Game.print_all("Squad has arrived at waypoint!")
+				else
+					local position = squad.patrolState.waypointList[squad.patrolState.currentWaypoint]
 
-            end
+					if validateSquadIntegrity(squad) then
+						squad.unitGroup.set_command(
+							{type=defines.command.go_to_location,
+							 destination=position, radius=DEFAULT_SQUAD_RADIUS,
+							 distraction=defines.distraction.by_enemy})
+					end
+				end
+			end
 
-            local waypointCount = table.countNonNil(squad.patrolState.waypointList)
-            --Game.print_all(string.format("Squad's waypoint count: %d", waypointCount))
-            if(waypointCount >= 2) then
-                if(squad.patrolState.currentWaypoint == -1) then
-                    --Game.print_all("Setting up initial conditions...")
-                    squad.patrolState.currentWaypoint = 0
-                    squad.patrolState.movingToNext = false
-                    squad.patrolState.arrived = true
-                end
-                --check if we are going to a waypoint, if we are, check if we are close yet
-                if(squad.patrolState.movingToNext == true) then
+			if(squad.patrolState.movingToNext == false and squad.patrolState.arrived == true) then
+				--Game.print_all("Setting new waypoint and giving orders!")
+				--adjust current waypoint, check for min/max issues, then issue command to move.
+				squad.patrolState.currentWaypoint = squad.patrolState.currentWaypoint + squad.patrolState.waypointDirection
 
-                    --get distance from squad position to the current waypoint
-                    local dist = util.distance(squad.unitGroup.position, squad.patrolState.waypointList[squad.patrolState.currentWaypoint])
-                    --Game.print_all("Checking if squad is near waypoint...")
-                    if dist < 5 then
-                        squad.patrolState.movingToNext = false
-                        squad.patrolState.arrived = true
-                        --Game.print_all("Squad has arrived at waypoint!")
-                    else
+				if squad.patrolState.currentWaypoint > waypointCount then
+					squad.patrolState.waypointDirection = -1 --reverse the waypoint iteration direction
+					squad.patrolState.currentWaypoint = squad.patrolState.currentWaypoint - 2  --set it to the second last waypoint
+				end
 
-                        local position = squad.patrolState.waypointList[squad.patrolState.currentWaypoint]
+				--from the direction value being negative
+				if(squad.patrolState.currentWaypoint == 0) then
 
-                        squad.unitGroup.set_command({type=defines.command.go_to_location, destination=position, radius=DEFAULT_SQUAD_RADIUS,
-                                                     distraction=defines.distraction.by_enemy})
+					squad.patrolState.waypointDirection = 1 --reverse the waypoint iteration direction
+					squad.patrolState.currentWaypoint = squad.patrolState.currentWaypoint + 2 --set it to the second waypoint
 
-                    end
+				end
 
-                end
+				squad.patrolState.movingToNext = true
+				squad.patrolState.arrived = false
 
-                if(squad.patrolState.movingToNext == false and squad.patrolState.arrived == true) then
-                    --Game.print_all("Setting new waypoint and giving orders!")
-                    --adjust current waypoint, check for min/max issues, then issue command to move.
-                    squad.patrolState.currentWaypoint = squad.patrolState.currentWaypoint + squad.patrolState.waypointDirection
+				local position = squad.patrolState.waypointList[squad.patrolState.currentWaypoint]
 
-                    if squad.patrolState.currentWaypoint > waypointCount then
-                        squad.patrolState.waypointDirection = -1 --reverse the waypoint iteration direction
-                        squad.patrolState.currentWaypoint = squad.patrolState.currentWaypoint - 2  --set it to the second last waypoint
-                    end
-
-                    --from the direction value being negative
-                    if(squad.patrolState.currentWaypoint == 0) then
-
-                        squad.patrolState.waypointDirection = 1 --reverse the waypoint iteration direction
-                        squad.patrolState.currentWaypoint = squad.patrolState.currentWaypoint + 2 --set it to the second waypoint
-
-                    end
-
-                    squad.patrolState.movingToNext = true
-                    squad.patrolState.arrived = false
-
-                    local position = squad.patrolState.waypointList[squad.patrolState.currentWaypoint]
-
-                    squad.unitGroup.set_command({type=defines.command.go_to_location, destination=position, radius=DEFAULT_SQUAD_RADIUS,
-                                                 distraction=defines.distraction.by_enemy})
-                    --squad.unitGroup.start_moving()
-
-                end
-            end
-        end
-    end
+				if validateSquadIntegrity(squad) then
+					squad.unitGroup.set_command(
+						{type=defines.command.go_to_location, destination=position,
+						 radius=DEFAULT_SQUAD_RADIUS,
+						 distraction=defines.distraction.by_enemy})
+				end
+				--squad.unitGroup.start_moving()
+			end
+		end
+	elseif isOldBattleOrder(squad) then
+		squad.lastBattleOrderTick = game.tick
+		validateSquadIntegrity(squad)
+	end
 end
 
 
 function doRallyBeaconUpdate()
     if global.Squads then
-        
+
         for _,force in pairs(game.forces) do
             local forceName = force.name
             if global.Squads[forceName] then
                 --if this force has any rally beacons in its table
                 if(global.rallyBeacons and global.rallyBeacons[forceName] and table.countValidElements(global.rallyBeacons[forceName]) >= 1) then
-                    
+
                     local forceBeacons = global.rallyBeacons[forceName]
                     local forceSquads = global.Squads[forceName]
                     for _, squad in pairs(forceSquads) do
@@ -268,9 +251,10 @@ function doRallyBeaconUpdate()
                                     --give them command to move.
                                     squad.rally = true
                                     squad.unitGroup.destroy()
-                                    validateSquadIntegrity(squad) --this recreates the unitgroup and re-adds the members
-                                    squad.unitGroup.set_command({type=defines.command.go_to_location, destination=beaconPos, distraction=defines.distraction.none})
-                                    squad.unitGroup.start_moving()
+                                    if validateSquadIntegrity(squad) then --this recreates the unitgroup and re-adds the members
+										squad.unitGroup.set_command({type=defines.command.go_to_location, destination=beaconPos, distraction=defines.distraction.none})
+										squad.unitGroup.start_moving()
+									end
                                     --else if(dist > 20 ) then
                                     --  squad.rally = nil
                                 end

--- a/robolib/SquadControl.lua
+++ b/robolib/SquadControl.lua
@@ -47,6 +47,7 @@ function attemptToMergeRetreatingSquadWithNearestAssemblingSquad(squad, range)
 											   range,
 											   squad, -- ignore self
 											   commands.assemble)
+	Game.print_force(squad.force, "Attempting to merge squad")
 	if closest_squad then
 		local oldsquadID = closest_squad.squadID
 		if mergeSquads(squad, closest_squad) then

--- a/robolib/eventhandlers.lua
+++ b/robolib/eventhandlers.lua
@@ -38,10 +38,15 @@ function runForceSquadUpdatesForTick(forces, tickProcessIndex)
             --for the current tick, look at the global table for that tick (mod 60) and any squad references in there.
             --LOGGER.log(string.format("Processing AI for AI tick %d of 60", tickProcessIndex))
             for i, squadref in pairs(global.updateTable[force.name][tickProcessIndex]) do
-                if squadref and global.Squads[force.name][squadref] then
-                    -- local squad = global.Squads[force.name][squadref]
-                    -- if not squad.force then squad.force = force
-                    updateSquad(global.Squads[force.name][squadref])
+                if squadref then
+					if global.Squads[force.name][squadref] then
+						-- local squad = global.Squads[force.name][squadref]
+						-- if not squad.force then squad.force = force
+						updateSquad(global.Squads[force.name][squadref])
+					else
+						-- the squad has been deleted at some point, so let's stop looping over it here.
+						global.updateTable[force.name][tickProcessIndex][i] = nil
+					end
                 end
             end
         end -- if enemy or neutral, do nothing for this force

--- a/robolib/onload.lua
+++ b/robolib/onload.lua
@@ -1,0 +1,80 @@
+require("robolib.Squad")
+require("stdlib/log/logger")
+require("stdlib/game")
+
+function global_ensureTablesExist()
+    if not global.updateTable then global.updateTable = {} end
+    if not global.Squads then global.Squads = {} end
+	if not global.AssemblerRetreatTables then global.AssemblerRetreatTables = {} end
+	if not global.RetreatingSquads then global.RetreatingSquads = {} end
+	if not global.DroidAssemblers then global.DroidAssemblers = {} end
+end
+
+
+function global_migrateSquadsToTickTable(forces)
+	LOGGER.log("verifying tick tables...")
+	-- ensure all squads are actually in the tick Tables
+	for fkey, force in pairs(forces) do
+		if force.name ~= "enemy" and force.name ~= "neutral" then
+			global_fixupTickTablesForForceName(force.name)
+			if not global.Squads[force.name] then goto continue end
+			for skey, squad in pairs(global.Squads[force.name]) do
+				local found = false
+				for tkey, tickTable in pairs(global.updateTable[force.name]) do
+					if table.contains(tickTable, squad.squadID) then
+						found = true
+						break
+					end
+				end
+				if not found then
+					squad = validateSquadIntegrity(squad)
+					if squad then
+						LOGGER.log(string.format("Inserting squad %d of size %d into tickTables", squad.squadID, squad.numMembers))
+						table.insert(global.updateTable[force.name][squad.squadID % 60 + 1], squad.squadID)
+					end
+				end
+			end
+		end
+		::continue::
+	end
+end
+
+
+function global_fixupTickTablesForForceName(force_name)
+    if not global.updateTable[force_name] then global.updateTable[force_name] = {} end
+
+    --check if the table has the 1st tick in it. if not, then go through and fill the table
+    if not global.updateTable[force_name][1] then
+        fillTableWithTickEntries(global.updateTable[force_name]) -- make sure it has got the 1-60 tick entries initialized
+    end
+
+	if not global.DroidAssemblers[force_name] then
+		global.DroidAssemblers[force_name] = {}
+	end
+	if not global.AssemblerRetreatTables[force_name] then
+		global.AssemblerRetreatTables[force_name] = {}
+	end
+	if not global.RetreatingSquads[force_name] then
+		global.RetreatingSquads[force_name] = {}
+	end
+
+    if not global.updateTable[force_name] or not global.Squads[force_name]  then
+        -- this is a more-or-less fatal error
+        -- in the condition of a new game, and you haven't placed a squad yet, can have issues with player force not having the squad table init yet.
+        global.Squads[force_name] = {}
+        return false
+
+        --disabling below code for now
+        --[[Game.print_all("Update Table or squad table for force is missing! Can't run update functions - force name:")
+        Game.print_all(force_name)
+        if not global.updateTable[force_name] then
+            Game.print_all("missing update table...")
+        end
+
+        if not global.Squads[force_name] then
+            Game.print_all("missing squad table...")
+        end
+        return false]]--
+    end
+    return true
+end

--- a/robolib/onload.lua
+++ b/robolib/onload.lua
@@ -8,6 +8,7 @@ function global_ensureTablesExist()
 	if not global.AssemblerRetreatTables then global.AssemblerRetreatTables = {} end
 	if not global.RetreatingSquads then global.RetreatingSquads = {} end
 	if not global.DroidAssemblers then global.DroidAssemblers = {} end
+	global.droidGuardStations = global.droidGuardStations or {}
 end
 
 
@@ -56,6 +57,18 @@ function global_fixupTickTablesForForceName(force_name)
 	end
 	if not global.RetreatingSquads[force_name] then
 		global.RetreatingSquads[force_name] = {}
+	end
+	if not global.droidGuardStations[force_name] then
+		global.droidGuardStations[force_name] = {}
+	end
+	if not global.droidCounters[force_name] then
+		global.droidCounters[force_name] = {}
+	end
+	if not global.lootChests[force_name] then
+		global.lootChests[force_name] = {}
+	end
+	if not global.uniqueSquadId[force_name] then
+		global.uniqueSquadId[force_name] = {}
 	end
 
     if not global.updateTable[force_name] or not global.Squads[force_name]  then

--- a/robolib/retreat.lua
+++ b/robolib/retreat.lua
@@ -1,0 +1,142 @@
+require("config.config")
+require("util")
+require("robolib.Squad")
+require("robolib.util")
+require("stdlib/log/logger")
+require("stdlib/game")
+
+-- this efficient AND reliable retreat logic has gotten so large that it really deserves its own file.
+
+
+function orderSquadToRetreat(squad)
+	local assembler = nil
+	local distance = 999999
+	if squad.retreatToAssembler and squad.retreatToAssembler.valid then
+		assembler = squad.retreatToAssembler
+		distance = util.distance(squad.unitGroup.position, assembler.position)
+	else
+		assembler, distance = findClosestAssemblerToPosition(
+			global.DroidAssemblers[squad.force.name], squad.unitGroup.position)
+	end
+
+	if assembler then
+		local lastPos = squad.unitGroup.position
+
+		if distance > AT_ASSEMBLER_RANGE then
+			-- don't give orders to retreat to a location we are already making progress towards
+			if not (assembler == squad.retreatToAssembler and squad.lastBattleOrderPos and
+				util.distance(squad.unitGroup.position, squad.lastBattleOrderPos)
+						> SANITY_CHECK_PROGRESS_DISTANCE)
+			then
+				-- issue an actual retreat command
+				debugSquadOrder(squad, "RETREAT TO ASSEMBLER", assembler.position)
+
+				addSquadToRetreatTables(squad, assembler)
+				orderToAssembler(squad.unitGroup, assembler)
+				squad.unitGroup.start_moving()
+			else
+				addSquadToRetreatTables(squad, assembler)
+			end
+		elseif squad.command == commands.hunt or isTimeForMergeCheck(squad) then
+			-- we're close enough already, and we haven't checked recently.
+			-- check for nearby squads to merge
+			addSquadToRetreatTables(squad, assembler)
+			squad.command = commands.assemble -- so we don't check again soon
+			attemptToMergeSquadWithNearbyAssemblingSquad(
+				squad, global.RetreatingSquads[squad.force.name], AT_ASSEMBLER_RANGE * 2)
+			-- this last function call may actually invalidate the squad
+		elseif not squad.retreatToAssembler then
+			addSquadToRetreatTables(squad, assembler)
+		end
+
+		squad.lastBattleOrderTick = game.tick
+		squad.lastBattleOrderPos = lastPos
+	end
+end
+
+
+function addSquadToRetreatTables(squad, targetAssembler)
+	LOGGER.log(string.format("Adding squad %d to retreat tables.", squad.squadID))
+	-- look for nearby assemblers and add squad to those tables as well
+	retreatAssemblers = findNearbyAssemblers(global.DroidAssemblers[squad.force.name],
+											 targetAssembler.position, AT_ASSEMBLER_RANGE)
+	for i=1, #retreatAssemblers do -- cool/faster iteration syntax
+		local assembler = retreatAssemblers[i]
+		LOGGER.log(string.format("Adding squad %d to retreat table of assembler at (%d,%d)",
+								 squad.squadID, assembler.position.x, assembler.position.y))
+		if not global.AssemblerRetreatTables[squad.force.name][assembler] then
+			global.AssemblerRetreatTables[squad.force.name][assembler] = {}
+		end
+		global.AssemblerRetreatTables[squad.force.name][assembler][squad.squadID] = squad
+		global.RetreatingSquads[squad.force.name][squad.squadID] = squad
+	end
+	squad.retreatToAssembler = targetAssembler
+end
+
+
+function checkRetreatAssemblersForMergeableSquads(assemblerRetreatTable)
+	for assembler, squads in pairs(assemblerRetreatTable) do
+		if not assembler.valid then
+			assemblerRetreatTable[assembler] = nil -- don't iterate over this one again
+		else -- assembler is still valid; proceed
+			local mergeableSquad = nil
+			local mergeableSquadDist = nil
+			LOGGER.log(string.format("Trying to merge squads near assembler at (%d,%d)",
+									 assembler.position.x, assembler.position.y))
+			local squadCount = 0
+			local squadCloseCount = 0
+			for squadID, squad in pairs(squads) do
+				if not squadStillExists(squad) or shouldHunt(squad) then
+					squads[squadID] = nil
+				else
+					squadCount = squadCount + 1
+					local dist = util.distance(squad.unitGroup.position,
+											   assembler.position)
+					if dist < MERGE_RANGE then
+						-- then this squad is close enough to be merged, if it is still valid
+						if validateSquadIntegrity(squad) then
+							squadCloseCount = squadCloseCount + 1
+							LOGGER.log(string.format(
+										   " ---- Squad %d sz %d is near its retreating assembler.",
+										   squad.squadID, squad.numMembers))
+							if mergeableSquad then -- we already found a mergeable squad nearby
+								-- are we close enough to this other squad to merge?
+								if util.distance(mergeableSquad.unitGroup.position,
+												 squad.unitGroup.position) < MERGE_RANGE
+								then
+									mergeableSquad = mergeSquads(squad, mergeableSquad)
+									if shouldHunt(mergeableSquad) then
+										squads[squadID] = nil
+										mergeableSquad = nil
+										mergeableSquadDist = nil
+									end
+								elseif mergeableSquadDist > dist then
+									-- our previous 'mergeableSquad' is a little too far away,
+									-- and may have retreated to a different, nearby assembler.
+									-- Since this merge was not okay, we will instead choose the current
+									-- squad, which is closer to the assembler, as the 'mergeableSquad' for
+									-- any future merge attempts.
+									mergeableSquad = squad
+									mergeableSquadDist = dist
+								end
+							else -- set first 'mergeable squad'
+								mergeableSquad = squad
+								mergeableSquadDist = dist
+							end
+						else
+							squads[squadID] = nil
+						end
+					elseif dist < 100 then
+						LOGGER.log(string.format("Squad %d is not close enough, but is at %d",
+												 squad.squadID, dist))
+					end
+				end
+			end
+			if squadCount == 0 then
+				assemblerRetreatTable[assembler] = nil -- don't iterate over this one again
+			end
+			LOGGER.log(string.format("We examined %d squads, of which %d were near this assembler",
+									 squadCount, squadCloseCount))
+		end
+	end
+end

--- a/robolib/util.lua
+++ b/robolib/util.lua
@@ -114,6 +114,16 @@ function checkGlobalTableInitStates()
 end
 
 
+function global_canAnyPlayersSeeThisEntity(entity)
+	for key, player in pairs(game.players) do
+		if player and util.distance(player.position, entity.position) < PLAYER_VIEW_RADIUS then
+			return true
+		end
+	end
+	return false
+end
+
+
 --waypointList is a list of LuaPositions,
 function getClosestEntity(position, entityList)
     local dist = 0
@@ -136,6 +146,7 @@ end
 
 --input is a sub-table of global.updateTable, and is the table for a particular force
 function fillTableWithTickEntries(inputTable)
+	-- Game.print_all("filling update tick table")
     for i = 1, 60 do
         inputTable[i] = {}
     end
@@ -148,7 +159,6 @@ function getLeastFullTickTable(force)
 
     --check if the table has the 1st tick in it. if not, then go through and fill the table
     if not global.updateTable[force.name][1] then
-        Game.print_all("filling update tick table")
         fillTableWithTickEntries(global.updateTable[force.name]) -- make sure it has got the 0-59 tick entries initialized
     end
 

--- a/robolib/util.lua
+++ b/robolib/util.lua
@@ -93,25 +93,23 @@ end
 
 
 --any new global tables we need to add, just add them in here and it will be easier to maintain. not used yet.
-function checkGlobalTableInitStates()
-    global.Squads = global.Squads or {}
-    global.uniqueSquadId = global.uniqueSquadId or {}
-    global.DroidAssemblers = global.DroidAssemblers or {}
-    global.droidCounters = global.droidCounters or {}
-    global.lootChests = global.lootChests or {}
-    global.droidGuardStations = global.droidGuardStations or {}
-    local forceList = game.forces
-    for _, force in pairs(forceList) do
-        global.droidGuardStations[force.name] = global.droidGuardStations[force.name] or {}
-        global.Squads[force.name] = global.Squads[force.name] or {}
-        global.DroidAssemblers[force.name] = global.DroidAssemblers[force.name] or {}
-        global.droidCounters[force.name] = global.droidCounters[force.name] or {}
-        global.lootChests[force.name] = global.lootChests[force.name] or {}
-        global.uniqueSquadId[force.name] = global.uniqueSquadId[force.name] or 1
-
-    end
-
-end
+-- function checkGlobalTableInitStates()
+--     global.Squads = global.Squads or {}
+--     global.uniqueSquadId = global.uniqueSquadId or {}
+--     global.DroidAssemblers = global.DroidAssemblers or {}
+--     global.droidCounters = global.droidCounters or {}
+--     global.lootChests = global.lootChests or {}
+--     global.droidGuardStations = global.droidGuardStations or {}
+--     local forceList = game.forces
+--     for _, force in pairs(forceList) do
+--         global.droidGuardStations[force.name] = global.droidGuardStations[force.name] or {}
+--         global.Squads[force.name] = global.Squads[force.name] or {}
+--         global.DroidAssemblers[force.name] = global.DroidAssemblers[force.name] or {}
+--         global.droidCounters[force.name] = global.droidCounters[force.name] or {}
+--         global.lootChests[force.name] = global.lootChests[force.name] or {}
+--         global.uniqueSquadId[force.name] = global.uniqueSquadId[force.name] or 1
+--     end
+-- end
 
 
 function global_canAnyPlayersSeeThisEntity(entity)


### PR DESCRIPTION
### Issues

This rather large set of changes attempts to address a number of issues.

1) Slow performance on retreat merges.
2) Unreliability of retreat merges. This happens for various reasons, but mostly because occasionally squads will not enter the gathering/finished state upon arriving at a commanded position.
3) Possibility for squads to occasionally go rogue and do random things. This seems to be related to the issue behind pt 2, above, but also may happen when a squad goes from having a command to having no commands at all.
4) Bad behavior when squads cannot path to an enemy.
5) Squad unit groups failing to make progress when the squad gets separated.

### Solutions

It addresses these in the following high-level ways:

1) Instead of scanning all existing squads every time a squad entering the range of an assembler and looking for a merge opportunity,the code now adds retreating squads to a global lookup table of retreating squads and scans that table alone.
2) The solution here, which also helps performance significantly, is to move the main responsibility for attempting merges to the assemblers themselves. Each assembler gets a list of squads that are attempting to retreat to it or to a nearby assembler. At a configurable tick rate, those assemblers will attempt to merge any squads that are in that list and also nearby. This is a very smooth O(n) operation, as opposed to the O(n^2) total work done by every merging squad checking every other merging squad.
3) Since we don't always get the opportunity to notice that a squad is looking for its next task, the code now occasionally checks on squads and makes sure they're doing something useful. If your bots do weird things like wander in your spaghetti, this should eventually catch them and ask them to go do something else!
4) Since there is no way to confirm that this is the cause, all we can do is react to the effect, which is the repeated destruction of the squad's unitGroup. If the squad's unitGroup fails too many times, this is almost always an indication that the unitGroup cannot fulfill the orders given to it. The solution is to completely disband the squad, placing each individual droid soldier into its own squad, which will all then retreat to an assembler. At the same time, a message will be printed to the player notifying them of this unusual circumstance. If the issue does turn out to be a biter on an island, perhaps the player can build a bridge to it and destroy it, or use some other means of eliminating it to solve the underlying issue.
5) If no player is nearby, we will attempt to solve straggler issues by teleporting the unit nearer to its squad. If this fails, the droid soldier will eventually be kicked out of the squad into its own squad, which should then retreat.


### Performance:

I have observed roughly 2-3x better median performance with this code on my laptop. I trust that will hold true for other systems as well. The periodic assembler merge checks will still cause minor spikes every few seconds when there are many squads retreating. This is a candidate for future improvement, but even on my relatively slow laptop the spikes are quite small, and they will be virtually non-existent during normal play when the large majority of squads are not retreating. 

### Misc

There is a lot of new logging in this code. Some of it will probably be helpful as this build gets tested, and maybe eventually as it goes into wider use. Some of it, no doubt, will be better off being commented out. 